### PR TITLE
Bugfix-URL-generation

### DIFF
--- a/src/util/LocalUrlGeneration.js
+++ b/src/util/LocalUrlGeneration.js
@@ -7,5 +7,5 @@ export function getBackendUrl() {
 }
 
 export function getFrontendUrl() {
-    return LOCAL ? "http://localhost:5173" : "https://enapiwek.onrender.com/";
+    return LOCAL ? "http://localhost:5173" : "https://enapiwek.onrender.com";
 }


### PR DESCRIPTION
Minor bugfix for getFrontendUrl() so that the returned string doesn't include "/" at the end 